### PR TITLE
[enh] Add move constructor for scopedconnection.

### DIFF
--- a/lib/scopedconnection.h
+++ b/lib/scopedconnection.h
@@ -58,6 +58,7 @@ public:
 	/// \param safe By default, we get the connection from the pool with
 	/// ConnectionPool::grab(), but we can call safe_grab() instead.
 	explicit ScopedConnection(ConnectionPool& pool, bool safe = false);
+	ScopedConnection(ScopedConnection&&) = default;
 
 	/// \brief Destructor
 	///
@@ -73,13 +74,14 @@ public:
 	/// \brief Truthiness operator
 	operator void*() const { return connection_; }
 
-private:
+public:
 	// ScopedConnection objects cannot be copied.  We want them to be
 	// tightly scoped to their use point, not put in containers or
 	// passed around promiscuously.
-	ScopedConnection(const ScopedConnection& no_copies);   
-	const ScopedConnection& operator=(const ScopedConnection& no_copies);
+	ScopedConnection(const ScopedConnection& no_copies) = delete;
+	const ScopedConnection& operator=(const ScopedConnection& no_copies) = delete;
 
+private:
 	ConnectionPool& pool_;
 	Connection* const connection_;
 };


### PR DESCRIPTION
Lack of move constructors. Need for this:
```cpp
std::shared_ptr<ConnectionPool> ctx = m_ctx;
mysqlpp::ScopedConnection conn(*ctx);

auto f = std::make_shared<std::future<void>>();
*f = std::async(std::launch::async,
            [this, f, ctx = std::move(ctx), conn = std::move(conn)]
            {
                        <do some magic>
            }
);

```